### PR TITLE
Disable generate button after link creation

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -56,6 +56,14 @@
       }
       .btn:hover{ filter:brightness(1.04); box-shadow:0 6px 14px var(--ember-glow); }
       .btn:active{ transform: translateY(1px); }
+      .btn:disabled{
+        opacity:.6;
+        cursor:not-allowed;
+        filter:grayscale(0.5);
+        box-shadow:none;
+      }
+      .btn:disabled:hover{ filter:grayscale(0.5); box-shadow:none; }
+      .btn:disabled:active{ transform:none; }
       .btn.secondary{
         background: linear-gradient(180deg, #444, #2a2a2a);
         box-shadow: 0 4px 10px rgba(0,0,0,.15);

--- a/popup.js
+++ b/popup.js
@@ -148,6 +148,7 @@ async function qbCreate({ text, ttlSeconds, maxReads, password }) {
       linkBox.textContent = link;
       result.style.display = "block";
       msgEl.textContent = password ? "Password-protected link ready." : "Link ready.";
+      btn.disabled = true;
     } catch (e) {
       msgEl.textContent = String(e?.message || e);
     }
@@ -165,5 +166,6 @@ async function qbCreate({ text, ttlSeconds, maxReads, password }) {
     linkBox.textContent = "";
     result.style.display = "none";
     msgEl.textContent = "";
+    btn.disabled = false;
   });
 })();


### PR DESCRIPTION
## Summary
- disable "Create Quickburn Link" button after generating a secret
- re-enable the button when user clears the link
- style disabled buttons to convey inactive state

## Testing
- no tests

------
https://chatgpt.com/codex/tasks/task_e_68acddda517c8329a006110443eb24e9